### PR TITLE
Sanitize the URL to fix XSS vulnerability

### DIFF
--- a/bookmark-manager-react-web-app-project/package.json
+++ b/bookmark-manager-react-web-app-project/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@braintree/sanitize-url": "^6.0.4",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",

--- a/bookmark-manager-react-web-app-project/src/components/CardComp.js
+++ b/bookmark-manager-react-web-app-project/src/components/CardComp.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { sanitizeUrl } from "@braintree/sanitize-url";
 
 const CardComp = (props) => {
   const backImageStyle = {
@@ -9,11 +10,12 @@ const CardComp = (props) => {
   };
 
   const mappedCardData = props.cards.map((card, i) => {
+    const safeHref = sanitizeUrl(card.linkHref);
     return (
       <div key={i} className="bookmarkCard">
         <div className="bookmarkCardImage" style={backImageStyle} />
         <div className="bookmarkCardLink">
-          <a target="_blank" rel="noopener noreferrer" href={card.linkHref}>
+          <a target="_blank" rel="noopener noreferrer" href={safeHref}>
             {card.linkName}
           </a>
         </div>

--- a/bookmark-manager-react-web-app-project/yarn.lock
+++ b/bookmark-manager-react-web-app-project/yarn.lock
@@ -1424,6 +1424,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@braintree/sanitize-url@^6.0.4":
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz#923ca57e173c6b232bbbb07347b1be982f03e783"
+  integrity sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==
+
 "@cnakazawa/watch@^1.0.3":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@cnakazawa/watch/-/watch-1.0.4.tgz#f864ae85004d0fcab6f50be9141c4da368d1656a"


### PR DESCRIPTION
## Fix for Cross-Site Scripting (XSS) Vulnerability

I've identified a Cross-Site Scripting (XSS) vulnerability in `bookmark-manager-react-web-app-project`.

**Vulnerability Details:**
- **Severity**: High/Critical
- **Description**: There's a risk of malicious script execution when the href of the <a /> element is controlled by an adversary.

**Steps to Reproduce:**
1. open https://book-mark-react.netlify.app/
2. Input `javascript:alert(1)` in the Url Link Input
3. use cmd/ctrl + click combination to click the bookmark
Then the malicious code alert(1) will be executed.

**Suggested Fix or Mitigation:**
Sanitize the href attribute value before passing it to an <a /> tag. 

I've already fixed and tested this issue, and have submitted a pull request with the necessary changes. Please review and merge my pull request at your earliest convenience to resolve this vulnerability. Thanks!


<img width="1218" alt="image" src="https://github.com/pramit-marattha/Fullstack-projects-frontend-with-react-and-backend-with-various-stacks/assets/149294029/f10a555b-7642-447f-8284-ae5fbc4bb422">
